### PR TITLE
check in lax mode

### DIFF
--- a/scripts/update_dumps.sh
+++ b/scripts/update_dumps.sh
@@ -11,10 +11,10 @@ DUMP_PATH=$2
 # djxl
 python3 ./third_party/conformance/scripts/conformance.py --decoder "./third_party/libjxl/build/tools/djxl" --corpus $CORPUS --results=$DUMP_PATH/dump_djxl.json
 # djxl via png
-python3 ./third_party/conformance/scripts/conformance.py --decoder "python3 scripts/wrap_png.py --decoder './third_party/libjxl/build/tools/djxl %s %s'" --corpus $CORPUS --results=$DUMP_PATH/dump_djxl_via_png.json
+python3 ./third_party/conformance/scripts/conformance.py --decoder "python3 scripts/wrap_png.py --decoder './third_party/libjxl/build/tools/djxl %s %s'" --corpus $CORPUS --results=$DUMP_PATH/dump_djxl_via_png.json --lax
 # jxl-oxide
-python3 ./third_party/conformance/scripts/conformance.py --decoder "python3 scripts/wrap_png.py --decoder 'jxl-dec %s -o %s'" --corpus $CORPUS --results=$DUMP_PATH/dump_jxl-dec.json
+python3 ./third_party/conformance/scripts/conformance.py --decoder "python3 scripts/wrap_png.py --decoder 'jxl-dec %s -o %s'" --corpus $CORPUS --results=$DUMP_PATH/dump_jxl-dec.json --lax
 # jxlatte
-python3 ./third_party/conformance/scripts/conformance.py --decoder "python3 scripts/wrap_png.py --decoder 'java -jar ./third_party/jxlatte/build/java/jxlatte.jar %s %s'" --corpus $CORPUS --results=$DUMP_PATH/dump_jxlatte.json
+python3 ./third_party/conformance/scripts/conformance.py --decoder "python3 scripts/wrap_png.py --decoder 'java -jar ./third_party/jxlatte/build/java/jxlatte.jar %s %s'" --corpus $CORPUS --results=$DUMP_PATH/dump_jxlatte.json --lax
 # j40
-python3 ./third_party/conformance/scripts/conformance.py --decoder "python3 scripts/wrap_png.py --decoder './third_party/j40/dj40 %s %s'" --corpus $CORPUS --results=$DUMP_PATH/dump_j40.json
+python3 ./third_party/conformance/scripts/conformance.py --decoder "python3 scripts/wrap_png.py --decoder './third_party/j40/dj40 %s %s'" --corpus $CORPUS --results=$DUMP_PATH/dump_j40.json --lax

--- a/scripts/wrap_png.py
+++ b/scripts/wrap_png.py
@@ -30,13 +30,15 @@ def write_metadata(args):
     with open(args.metadata_out, 'w') as f:
         json.dump({"frames": [ { "name": "", } ], }, f)
 
+# Skip for now
 def write_orig_icc(args):
-    with open(args.orig_icc_out, 'w') as f:
-        pass
+    return
 
-def write_icc(args):
-    with open(args.icc_out, 'w') as f:
-        pass
+# Placeholder: let ImageMagick extract an icc profile from the PNG
+# This will only work if the PNG has an icc profile in the first place
+# TODO(jon): make this also work for PNG files that use other ways to signal their colorspace
+def write_icc(temp_file, args):
+    subprocess.run(["convert", temp_file.name, args.icc_out])
 
 def write_reconstruct_jpg(args):
     with open(args.output, 'w') as f:
@@ -78,10 +80,10 @@ def main():
 
     with tempfile.NamedTemporaryFile(suffix=".png") as temp_file:
         convert_to_png(temp_file, args)
+        write_icc(temp_file, args)
         convert_to_numpy_array(temp_file, args)
     write_metadata(args)
     write_orig_icc(args)
-    write_icc(args)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Do the conformance check in lax mode when going through PNG, i.e. don't check the `original.icc` and check the values after clamping (since PNG cannot represent values outside 0..1).