### PR TITLE
scripts/wrap_png.py: check if file exists before calling getsize

### DIFF
--- a/scripts/wrap_png.py
+++ b/scripts/wrap_png.py
@@ -45,7 +45,7 @@ def write_orig_icc(args):
 # TODO(jon): make this also work for PNG files that use other ways to signal their colorspace
 def write_icc(temp_file, args, nbchans):
     subprocess.run(["convert", temp_file.name, args.icc_out])
-    if (os.path.getsize(args.icc_out) == 0):
+    if not os.path.exists(args.icc_out) or os.path.getsize(args.icc_out) == 0:
         if nbchans >= 3:
             with open('scripts/sRGB.icc', 'rb') as file:
                 binary_data = file.read()


### PR DESCRIPTION
On some platforms (e.g. Linux), os.file.getsize throws an exception rather than returning zero if the file doesn't exist. We check for this as well before we spit out a dummy ICC profile, or numpy will report no frame data on those files.